### PR TITLE
优化 model_norm 方法

### DIFF
--- a/chapter15_Differential_Privacy/models.py
+++ b/chapter15_Differential_Privacy/models.py
@@ -26,9 +26,13 @@ def get_model(name="vgg16", pretrained=True):
 	else:
 		return model 
 		
+
 def model_norm(model_1, model_2):
-	squared_sum = 0
-	for name, layer in model_1.named_parameters():
-	#	print(torch.mean(layer.data), torch.mean(model_2.state_dict()[name].data))
-		squared_sum += torch.sum(torch.pow(layer.data - model_2.state_dict()[name].data, 2))
-	return math.sqrt(squared_sum)
+    params_1 = torch.cat([param.view(-1) for param in model_1.parameters()])
+    params_2 = torch.cat([param.view(-1) for param in model_2.parameters()])
+    
+    return torch.norm(params_1 - params_2, p = 2)
+
+def quick_model_norm(model_1, model_2):
+    diffs = [(p1 - p2).view(-1) for p1, p2 in zip(model_1.parameters(), model_2.parameters())]
+    return torch.norm(torch.cat(diffs), p = 2)


### PR DESCRIPTION
对于张量运算应尽量避免使用循环，原版的 model_norm 函数 (i.e. 计算两个模型之间的欧式距离) 使用 for 实现，导致效率偏低且可读性差。为此我们优化了原版 model_norm 方法，增强了可读性且运行效率提高了一倍，若在 GPU 环境之中运行代码， 性能提升会更加显著。

```python
# 原本的 model_norm 方法之中的 for 循环导致其无法充分利用 GPU 加速
def model_norm(model_1, model_2):
	squared_sum = 0
	for name, layer in model_1.named_parameters():
		squared_sum += torch.sum(torch.pow(layer.data - model_2.state_dict()[name].data, 2))
	return math.sqrt(squared_sum)

# 优化之后的 model_norm 方法，这个方法兼具运行效率与可读性
def model_norm2(model_1, model_2):
    params_1 = torch.cat([param.view(-1) for param in model_1.parameters()])
    params_2 = torch.cat([param.view(-1) for param in model_2.parameters()])
    
    return torch.norm(params_1 - params_2, p = 2)
    
# 如果牺牲一部分可读性，其运行效率可以进一步提高，实战之中使用下面代码能有效缩短模型训练的时间。
def quick_model_norm(model_1, model_2):
    diffs = [(p1 - p2).view(-1) for p1, p2 in zip(model_1.parameters(), model_2.parameters())]
    return torch.norm(torch.cat(diffs), p = 2)
```